### PR TITLE
업비트 구매한 코인정보, 비트코인 슬랙 메세지 발송

### DIFF
--- a/SlackWebhooks.php
+++ b/SlackWebhooks.php
@@ -1,0 +1,23 @@
+<?php
+class SlackWebhooks
+{
+    public function sendMessage($message, $url=null) {
+        $url = $url == null ? "https://hooks.slack.com/services/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" : $url;
+        $messageArray = array("text" => $message);
+        $messageJson = json_encode($messageArray);
+        
+        $ch = curl_init(); //curl 초기화
+        curl_setopt($ch, CURLOPT_URL, $url); //URL 지정하기
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true); //요청 결과를 문자열로 반환 
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1000); //connection timeout 1초 
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true); //원격 서버의 인증서가 유효한지 검사 안함
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $messageJson);       //POST data
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+            "Content-Type:application/json",
+        ));
+        
+        $response = curl_exec($ch);
+        curl_close($ch);
+	}
+}
+?>

--- a/SlackWebhooks.php
+++ b/SlackWebhooks.php
@@ -2,7 +2,7 @@
 class SlackWebhooks
 {
     public function sendMessage($message, $url=null) {
-        $url = $url == null ? "https://hooks.slack.com/services/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" : $url;
+        $url = $url == null ? "https://hooks.slack.com/services/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" : $url;
         $messageArray = array("text" => $message);
         $messageJson = json_encode($messageArray);
         

--- a/database/DBConnect.php
+++ b/database/DBConnect.php
@@ -28,14 +28,21 @@ class DBConnect extends DBData
         return $return;
     }
 
-    public function queryExecute($query){
+    public function queryExecute($query) {
         $result = mysqli_query($this->connect, $query);
 
         return $result;
     }
 
+    public function getSelectOneRow($query) {
+        $result_set = $this->queryExecute($query);
+        $row = mysqli_fetch_array($result_set);
+
+        return $row;
+    }
+
     protected function connectExit() {
-        //mysql_close($this->connect);
+        mysqli_close($this->connect);
     }
 
     function __destruct()

--- a/getAccount.php
+++ b/getAccount.php
@@ -1,4 +1,9 @@
 <?php
+$serverIP = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : "127.0.0.1"; // console실행 처이
+if($serverIP != "193.123.253.106" && $serverIP != "114.206.48.234" && $serverIP != "127.0.0.1") {
+    exit();
+}
+
 include_once  dirname(__FILE__)."/database/DBData.php";
 include_once  dirname(__FILE__)."/upbit/UpitData.php";
 
@@ -11,15 +16,10 @@ $upbit = new Upbit;
 $dbconnect = new DBConnect;
 $slack = new SlackWebhooks;
 
-$serverIP = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : "127.0.0.1"; // console실행 처이
-if($serverIP != "193.123.253.106" && $serverIP != "114.206.48.234" && $serverIP != "127.0.0.1") {
-    exit();
-}
-
 $upbitAccount = $upbit->getAccount();
 
 $message = "";
-
+$increase = "";
 if($upbitAccount["result"] == true) {
     $accountData = $upbitAccount["data"];
 
@@ -27,6 +27,7 @@ if($upbitAccount["result"] == true) {
         $currency = $value["currency"];
         $markets = $value["unit_currency"] . "-" . $value["currency"];
         $balance = $value["balance"];
+		$avg_buy_price = $value["avg_buy_price"];
 
         $ticker = $upbit->getTicker($markets);
         if($ticker["result"] === true){
@@ -42,14 +43,20 @@ if($upbitAccount["result"] == true) {
 
             $message .= $marketInfo["korean_name"] . "\n";
             $message .= "수량 : " . $balance . " " . $currency . "\n";
-            $message .= "시가 : " . $trade_price . "\n";
+			$message .= "매수가 : " . $avg_buy_price . "\n";
+            $message .= "종가 : " . $trade_price . "\n";
             $message .= "총계 : " . number_format($totlaKRW) . "\n\n";
+			
+            $increaseValue = $trade_price * 100.0 / $avg_buy_price - 100;
+            $revenueValue = $tradeTotlaKRW - $buyTotlaKRW;
+
+            $increase .= $marketInfo["korean_name"] . " : " . number_format($revenueValue) . "(" . $increaseValue . "%) \n";
         }
     }
+	$message .= "\n\n" . $increase;
 } else {
     $message = "오류 : " . date("Y-m-d h:m:s");
 }
 
-$sendUrl = "https://hooks.slack.com/services/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";
-$slack->sendMessage($message, $sendUrl);
+$slack->sendMessage($message);
 ?>

--- a/getAccount.php
+++ b/getAccount.php
@@ -1,0 +1,55 @@
+<?php
+include_once  dirname(__FILE__)."/database/DBData.php";
+include_once  dirname(__FILE__)."/upbit/UpitData.php";
+
+include_once  dirname(__FILE__)."/database/DBConnect.php";
+include_once  dirname(__FILE__)."/upbit/Upbit.php";
+
+include_once  dirname(__FILE__)."/SlackWebhooks.php";
+
+$upbit = new Upbit;
+$dbconnect = new DBConnect;
+$slack = new SlackWebhooks;
+
+$serverIP = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : "127.0.0.1"; // console실행 처이
+if($serverIP != "193.123.253.106" && $serverIP != "114.206.48.234" && $serverIP != "127.0.0.1") {
+    exit();
+}
+
+$upbitAccount = $upbit->getAccount();
+
+$message = "";
+
+if($upbitAccount["result"] == true) {
+    $accountData = $upbitAccount["data"];
+
+    foreach ($accountData as $key => $value) {
+        $currency = $value["currency"];
+        $markets = $value["unit_currency"] . "-" . $value["currency"];
+        $balance = $value["balance"];
+
+        $ticker = $upbit->getTicker($markets);
+        if($ticker["result"] === true){
+            $query = "
+                SELECT korean_name 
+                FROM market
+                WHERE market = '" . $markets . "'
+            ";
+            $marketInfo = $dbconnect->getSelectOneRow($query);
+            $trade_price = $ticker["data"][0]["trade_price"];
+
+            $totlaKRW = $balance * $trade_price;
+
+            $message .= $marketInfo["korean_name"] . "\n";
+            $message .= "수량 : " . $balance . " " . $currency . "\n";
+            $message .= "시가 : " . $trade_price . "\n";
+            $message .= "총계 : " . number_format($totlaKRW) . "\n\n";
+        }
+    }
+} else {
+    $message = "오류 : " . date("Y-m-d h:m:s");
+}
+
+$sendUrl = "https://hooks.slack.com/services/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";
+$slack->sendMessage($message, $sendUrl);
+?>

--- a/getRevenue.php
+++ b/getRevenue.php
@@ -1,0 +1,74 @@
+<?php
+$serverIP = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : "127.0.0.1"; // console실행 처이
+if($serverIP != "193.123.253.106" && $serverIP != "114.206.48.234" && $serverIP != "127.0.0.1") {
+    exit();
+}
+
+include_once  dirname(__FILE__)."/database/DBData.php";
+include_once  dirname(__FILE__)."/upbit/UpitData.php";
+
+include_once  dirname(__FILE__)."/database/DBConnect.php";
+include_once  dirname(__FILE__)."/upbit/Upbit.php";
+
+include_once  dirname(__FILE__)."/SlackWebhooks.php";
+
+$upbit = new Upbit;
+$dbconnect = new DBConnect;
+$slack = new SlackWebhooks;
+
+$upbitAccount = $upbit->getAccount();
+
+$warningMessage = "";
+$revenueMessage = "";
+$increase = "";
+if($upbitAccount["result"] == true) {
+    $accountData = $upbitAccount["data"];
+
+    foreach ($accountData as $key => $value) {
+        $currency = $value["currency"];
+        $markets = $value["unit_currency"] . "-" . $value["currency"];
+        $balance = $value["balance"];
+		$avg_buy_price = $value["avg_buy_price"];
+
+        $ticker = $upbit->getTicker($markets);
+        if($ticker["result"] === true){
+            $query = "
+                SELECT korean_name 
+                FROM market
+                WHERE market = '" . $markets . "'
+            ";
+            $marketInfo = $dbconnect->getSelectOneRow($query);
+            $trade_price = $ticker["data"][0]["trade_price"];
+
+            $tradeTotlaKRW = $balance * $trade_price;
+            $buyTotlaKRW = $balance * $avg_buy_price;
+
+			$increaseValue = $trade_price * 100.0 / $avg_buy_price - 100;
+            $revenueValue = $tradeTotlaKRW - $buyTotlaKRW;
+
+            if($revenueValue < -5000 || $increaseValue < -10) {
+			    $warningMessage .= $marketInfo["korean_name"] . " : " . number_format($revenueValue) . "(" . $increaseValue . "%) \n";
+            }
+            if($revenueValue > 5000 || $increaseValue > 10) {
+                $revenueMessage .= $marketInfo["korean_name"] . " : " . number_format($revenueValue) . "(" . $increaseValue . "%) \n";
+            }
+        }
+    }
+} else {
+    $message = "오류 : " . date("Y-m-d h:m:s");
+}
+
+if($warningMessage != null) {
+    $warningMessage = "\n경고\n" . $warningMessage;
+}
+
+if($revenueMessage != null) {
+    $revenueMessage = "\n수익\n" . $revenueMessage;
+}
+$message = $warningMessage . $revenueMessage;
+
+if($message != null) {
+    $sendUrl = "https://hooks.slack.com/services/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";
+    $slack->sendMessage($message, $sendUrl);
+}
+?>

--- a/upbit/Upbit.php
+++ b/upbit/Upbit.php
@@ -71,7 +71,7 @@ class Upbit extends UpitData
                         "Authorization: " . $authorize_token . "\r\n"
             )
         );
-        
+        var_dump($authorize_token);
         $context = stream_context_create($opts);
         
         // Open the file using the HTTP headers set above
@@ -87,7 +87,42 @@ class Upbit extends UpitData
         return $return;
     }
 
-    function gen_uuid() {
+    public function getTicker($markets) {
+        // 변수 설정
+        $access_key = $this->AccessKey; // 키
+        $secret_key = $this->SecretKey; // 키
+
+        // 리턴값 기본 설정
+        $return = array();
+        $return['result'] = false;
+        $return['data'] = array();
+
+        $url = "https://api.upbit.com/v1/ticker?markets=" . $markets;
+        $opts = array(
+            'http'=>array(
+              'method'=>"GET",
+              'header'=>"Accept-language: en\r\n" .
+                        "Cookie: foo=bar\r\n" .
+                        "User-agent: BROWSER-DESCRIPTION-HERE\r\n"
+            )
+        );
+        
+        $context = stream_context_create($opts);
+        
+        // Open the file using the HTTP headers set above
+        $response = file_get_contents($url, false, $context);
+        
+        if($response == false){
+            $return['result'] = false;
+        } else {
+            $return['result'] = true;
+            $return['data'] = json_decode($response, true);
+        }
+        
+        return $return;
+    }
+
+    public function gen_uuid() {
         return sprintf( '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
             // 32 bits for "time_low"
             mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff ),

--- a/upbit/Upbit.php
+++ b/upbit/Upbit.php
@@ -71,7 +71,7 @@ class Upbit extends UpitData
                         "Authorization: " . $authorize_token . "\r\n"
             )
         );
-        var_dump($authorize_token);
+
         $context = stream_context_create($opts);
         
         // Open the file using the HTTP headers set above


### PR DESCRIPTION
# 업비트 구매한 코인정보, 비트코인 슬랙 메세지 발송

 - 1분마다 크론이 도는 getRevenue.php
   - 현재 구매한 코인의 일정 퍼센트가 넘은면 메세지 발송
   - 비트코인 정보 슬랙으로 발송
 
-  10분마다 크론이 도는 getAccount.php
   - 현재 구매한 모든 코인 정보
   - 비트코인 정보 슬랙으로 발송

 - 슬랙 API를 활용하여 메시지 발송
   - SlackWebhooks.php