### PR TITLE
코인정보 크론, 슬랙정보, ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .vscode/sftp.json
+config/UpitData.php
+database/DBData.php
+upbit/UpitData.php

--- a/SlackWebhooks.php
+++ b/SlackWebhooks.php
@@ -2,7 +2,7 @@
 class SlackWebhooks
 {
     public function sendMessage($message, $url=null) {
-        $url = $url == null ? "https://hooks.slack.com/services/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" : $url;
+        $url = $url == null ? "https://hooks.slack.com/services/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" : $url;
         $messageArray = array("text" => $message);
         $messageJson = json_encode($messageArray);
         

--- a/getAccount.php
+++ b/getAccount.php
@@ -20,6 +20,7 @@ $upbitAccount = $upbit->getAccount();
 
 $message = "";
 $increase = "";
+$revenueTotal = 0;
 if($upbitAccount["result"] == true) {
     $accountData = $upbitAccount["data"];
 
@@ -39,24 +40,35 @@ if($upbitAccount["result"] == true) {
             $marketInfo = $dbconnect->getSelectOneRow($query);
             $trade_price = $ticker["data"][0]["trade_price"];
 
-            $totlaKRW = $balance * $trade_price;
+            $tradeTotlaKRW = $balance * $trade_price;
+            $buyTotlaKRW = $balance * $avg_buy_price;
 
             $message .= $marketInfo["korean_name"] . "\n";
             $message .= "수량 : " . $balance . " " . $currency . "\n";
 			$message .= "매수가 : " . $avg_buy_price . "\n";
             $message .= "종가 : " . $trade_price . "\n";
-            $message .= "총계 : " . number_format($totlaKRW) . "\n\n";
+            $message .= "총계 : " . number_format($buyTotlaKRW) . "\n\n";
 			
             $increaseValue = $trade_price * 100.0 / $avg_buy_price - 100;
             $revenueValue = $tradeTotlaKRW - $buyTotlaKRW;
+            $revenueTotal = $revenueTotal + $revenueValue;
 
             $increase .= $marketInfo["korean_name"] . " : " . number_format($revenueValue) . "(" . $increaseValue . "%) \n";
         }
+        
     }
 	$message .= "\n\n" . $increase;
 } else {
     $message = "오류 : " . date("Y-m-d h:m:s");
 }
+
+$message .= "\n 총 수익 : " . number_format(round($revenueTotal));
+
+
+$btc = $upbit->getTicker("KRW-BTC");
+
+$message .= "\n 상한 : " . $btc["data"][0]["trade_price"];
+$message .= "\n 비트코인 현재가 : " . $btc["data"][0]["trade_price"];
 
 $slack->sendMessage($message);
 ?>

--- a/upbit/Upbit.php
+++ b/upbit/Upbit.php
@@ -10,8 +10,8 @@ class Upbit extends UpitData
 
     public function getInfo() {
         $return = array();
-        $return['result'] = false;
-        $return['data'] = array();
+        $return["result"] = false;
+        $return["data"] = array();
 
         $url = "https://api.upbit.com/v1/market/all?isDetails=false";
 
@@ -25,10 +25,10 @@ class Upbit extends UpitData
         curl_close($ch);
 
         if($response == false){
-            $return['result'] = false;
+            $return["result"] = false;
         } else {
-            $return['result'] = true;
-            $return['data'] = json_decode($response, true);
+            $return["result"] = true;
+            $return["data"] = json_decode($response, true);
         }
 
         return $return;
@@ -41,8 +41,8 @@ class Upbit extends UpitData
 
         // 리턴값 기본 설정
         $return = array();
-        $return['result'] = false;
-        $return['data'] = array();
+        $return["result"] = false;
+        $return["data"] = array();
 
         $params = array();
 
@@ -78,10 +78,10 @@ class Upbit extends UpitData
         $response = file_get_contents($url, false, $context);
 
         if($response == false){
-            $return['result'] = false;
+            $return["result"] = false;
         } else {
-            $return['result'] = true;
-            $return['data'] = json_decode($response, true);
+            $return["result"] = true;
+            $return["data"] = json_decode($response, true);
         }
 
         return $return;
@@ -94,8 +94,8 @@ class Upbit extends UpitData
 
         // 리턴값 기본 설정
         $return = array();
-        $return['result'] = false;
-        $return['data'] = array();
+        $return["result"] = false;
+        $return["data"] = array();
 
         $url = "https://api.upbit.com/v1/ticker?markets=" . $markets;
         $opts = array(
@@ -113,10 +113,10 @@ class Upbit extends UpitData
         $response = file_get_contents($url, false, $context);
         
         if($response == false){
-            $return['result'] = false;
+            $return["result"] = false;
         } else {
-            $return['result'] = true;
-            $return['data'] = json_decode($response, true);
+            $return["result"] = true;
+            $return["data"] = json_decode($response, true);
         }
         
         return $return;


### PR DESCRIPTION
# 코인정보 크론, 슬랙정보, ignore


- 1분마다 크론이 도는 getRevenue.php
   - 현재 구매한 코인의 일정 퍼센트가 넘은면 메세지 발송
   - 비트코인 정보 슬랙으로 발송
   - 10분마다 크론이 도는 getAccount.php

 - 현재 구매한 모든 코인 정보
   - 비트코인 정보 슬랙으로 발송
 
- ignore
   - 보안정보 추가
  
 - 슬랙 바뀐 url 수정  